### PR TITLE
Update BCIMenu.cs

### DIFF
--- a/Assets/Car EMG/Scenes/Track.unity
+++ b/Assets/Car EMG/Scenes/Track.unity
@@ -2285,7 +2285,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5af2d9f1c19bb8d41878dda64196b95d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  verbose: 0
+  verbose: 1
   attemptConnectionOnStartup: 1
   allowWifi: 0
   flexedChannels: 0000000000000000
@@ -109661,7 +109661,19 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1119724927}
+        m_TargetAssemblyTypeName: BCIMenu, Assembly-CSharp
+        m_MethodName: WifiBoardName
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []
@@ -109679,19 +109691,7 @@ MonoBehaviour:
       m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1119724927}
-        m_TargetAssemblyTypeName: BCIMenu, Assembly-CSharp
-        m_MethodName: WifiBoardName
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   m_OnTouchScreenKeyboardStatusChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Car EMG/Scripts/BCIMenu.cs
+++ b/Assets/Car EMG/Scripts/BCIMenu.cs
@@ -101,7 +101,7 @@ public class BCIMenu : MonoBehaviour
 
     public void SetThresholdBar(int slider)
     {
-        if (slider >= 0 && slider <= 1)
+        if (zeroSlider.value >= 0 && zeroSlider.value <= 1)
         {
             bciReader.SetThreshold(slider, zeroSlider.value);
         }
@@ -112,11 +112,13 @@ public class BCIMenu : MonoBehaviour
     
     public void SetThresholdParameter(int slider)
     {
-        if (Int32.TryParse(zeroParameter.GetComponent<TMP_InputField>().text, out int value)){
+        if (Int32.TryParse(zeroParameter.GetComponent<TMP_InputField>().text, out int value))
+        {
             if (value >= 1 && value <= 1000)
             {
                 bciReader.SetThresholdSensitivity(slider, value);
-            }else if (bciReader.GetVerbose())
+            }
+            else if (bciReader.GetVerbose())
             {
                 Debug.Log("Threshold Parameter outside of range");
             }

--- a/Assets/Car EMG/Scripts/BCIMenu.cs
+++ b/Assets/Car EMG/Scripts/BCIMenu.cs
@@ -101,12 +101,30 @@ public class BCIMenu : MonoBehaviour
 
     public void SetThresholdBar(int slider)
     {
-        bciReader.SetThreshold(slider, zeroSlider.value);
+        if (slider >= 0 && slider <= 1)
+        {
+            bciReader.SetThreshold(slider, zeroSlider.value);
+        }
+        else if(bciReader.GetVerbose()){
+            Debug.Log("Threshold outside of range");
+        }
     }
     
     public void SetThresholdParameter(int slider)
     {
-        bciReader.SetThresholdSensitivity(slider, Int32.Parse(zeroParameter.GetComponent<TMP_InputField>().text));
+        if (Int32.TryParse(zeroParameter.GetComponent<TMP_InputField>().text, out int value)){
+            if (value >= 1 && value <= 1000)
+            {
+                bciReader.SetThresholdSensitivity(slider, value);
+            }else if (bciReader.GetVerbose())
+            {
+                Debug.Log("Threshold Parameter outside of range");
+            }
+        }
+        else if (bciReader.GetVerbose())
+        {
+            Debug.Log("Invalid Threshold Parameter, unable to parse");
+        }
     }
 
     public void Resume()
@@ -136,20 +154,46 @@ public class BCIMenu : MonoBehaviour
 
     public void Board_Type()
     {
-        bciReader.SetAllowWifi(boardType.value == 1);
-        if (boardType.value == 1)
+        if (boardType.value == 1 || boardType.value == 0)
         {
-            boardName.SetActive(true);
-        }
-        else
-        {
-            boardName.SetActive(false);
+            bciReader.SetAllowWifi(boardType.value == 1);
+            if (boardType.value == 1)
+            {
+                boardName.SetActive(true);
+            }
+            else
+            {
+                boardName.SetActive(false);
+            }
         }
     }
 
     public void WifiBoardName()
     {
-        bciReader.SetWifiBoardName(boardName.GetComponent<TMP_InputField>().text);
+        name = boardName.GetComponent<TMP_InputField>().text;
+        if (name.Length == 12 && name.Substring(0, 8).Equals("OpenBCI-")) 
+        {
+            bool valid = true;
+            foreach(char c in name.Substring(8))
+            {
+                if (!Char.IsLetterOrDigit(c))
+                {
+                    valid = false;
+                }
+            }
+            if (valid)
+            {
+                bciReader.SetWifiBoardName(name);
+            }
+            else if (bciReader.GetVerbose())
+            {
+                Debug.Log("Board code contains non alphanumeric character");
+            }
+        }
+        else if (bciReader.GetVerbose())
+        {
+            Debug.Log("Invalid board name, board name should follow \"OpenBCI-XXXX\" format");
+        }
     }
 
     public void Disconnect_Board()


### PR DESCRIPTION
Added Input checking (Some functions take values from the Unity input elements and apply them to the bciReader object, which handles connections to the brain computer interface equipment as well as thresholds/input parsing. The Unity input elements don't have enough restrictions to ensure that we only accept safe input. Additional checks should be implemented according to the below specifications so that only appropriate values are applied to the bciReader object)